### PR TITLE
Initializing variables

### DIFF
--- a/src/cg_accel.c
+++ b/src/cg_accel.c
@@ -2196,7 +2196,7 @@ static void PM_Accelerate(const vec3_t wishdir, float const wishspeed, float con
         }
 
         // get edges height per case
-        float lh, rh;
+        float lh = 0, rh = 0;
 
         if(accel_edge_height.value > 0){
           if(accel_edge.integer & ACCEL_EDGE_RELATIVE_HEIGHT){


### PR DESCRIPTION
There were uninitialized variables and the program was not able to compile with some compilers.